### PR TITLE
quick fix for js credentials

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,9 @@
 class HomeController < ApplicationController
 
   def index
+    @init_props = {
+      patreonRedirect: ENV['PATREON_REDIRECT'],
+      patreonClientId: ENV['PATREON_CLIENT_ID']
+    }
   end
 end

--- a/app/javascript/packs/streaming.js
+++ b/app/javascript/packs/streaming.js
@@ -3,13 +3,13 @@
 import App from '../app/App.svelte'
 
 document.addEventListener('DOMContentLoaded', () => {
+  const node = document.getElementById('init_props')
+  const data = node.getAttribute('data')
   const app = new App({
     target: document.body,
-    props: {
-      patreonRedirect: process.env.PATREON_REDIRECT,
-      patreonClientId: process.env.PATREON_CLIENT_ID
-    }
+    props: JSON.parse(data)
   });
+  node.remove()
 
   window.app = app;
 })

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,1 @@
+<%= content_tag :span, "", { id: 'init_props', data: @init_props.to_json} %>


### PR DESCRIPTION
Fixes #31

I... don't like this. It'll work for now but I'm looking at other ways to manage env vars in prod. Currently we're relying on rbenv vars but it seems webpacker doesn't play nice with that. 